### PR TITLE
Added english language files

### DIFF
--- a/src/dma_simple_grid/languages/de/modules.php
+++ b/src/dma_simple_grid/languages/de/modules.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * Back end modules
- */
-$GLOBALS['TL_LANG']['MOD']['dma_simple_grid'] = array('DMA SimpleGrid', 'DMA SimpleGrid');

--- a/src/dma_simple_grid/languages/de/modules.php
+++ b/src/dma_simple_grid/languages/de/modules.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Back end modules
+ */
+$GLOBALS['TL_LANG']['MOD']['dma_simple_grid'] = array('DMA SimpleGrid', 'DMA SimpleGrid');

--- a/src/dma_simple_grid/languages/en/default.php
+++ b/src/dma_simple_grid/languages/en/default.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Content elements
+ */
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid']               = 'Grid System (DMA SimpleGrid)';
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid_wrapper_start'] = array('Grid Wrapper Start');
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid_wrapper_stop']  = array('Grid Wrapper Stop');
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid_row_start']     = array('Grid Row Start');
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid_row_stop']      = array('Grid Row Stop');
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid_column_start']  = array('Grid Column Start');
+$GLOBALS['TL_LANG']['CTE']['dma_simplegrid_column_stop']   = array('Grid Column Stop');
+
+/**
+ * Form fields
+ */
+$GLOBALS['TL_LANG']['FFL']['dma_simplegrid_row_start']    = array('Grid Row Start');
+$GLOBALS['TL_LANG']['FFL']['dma_simplegrid_row_stop']     = array('Grid Row Stop');
+$GLOBALS['TL_LANG']['FFL']['dma_simplegrid_column_start'] = array('Grid Column Start');
+$GLOBALS['TL_LANG']['FFL']['dma_simplegrid_column_stop']  = array('Grid Column Stop');

--- a/src/dma_simple_grid/languages/en/modules.php
+++ b/src/dma_simple_grid/languages/en/modules.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Back end modules
+ */
+$GLOBALS['TL_LANG']['MOD']['dma_simple_grid'] = array('DMA SimpleGrid');

--- a/src/dma_simple_grid/languages/en/tl_content.php
+++ b/src/dma_simple_grid/languages/en/tl_content.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_columnsettings']           = array('Column settings', 'Here you can configure the grid columns.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_offsetsettings']           = array('Offset settings', 'Here you can configure the grid offset.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_offsetrightsettings']      = array('Offset-Right settings', 'Here you can configure the grid right-offset.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_pullsettings']             = array('Pull settings', 'Here you can configure the grid pull.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_pushsettings']             = array('Push settings', 'Here you can configure the grid push.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_additionalcolumnclasses']  = array('Additional column classes', 'Optionally select additional column classes for this element.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_additionalrowclasses']     = array('Additional row classes', 'Optionally select additional row classes for this element.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_additionalwrapperclasses'] = array('Additional wrapper classes', 'Optionally select additional wrapper classes for this element.');
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_blocksettings']            = array('Block grid settings', 'Here you can configure the block grid.');
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_content']['dma_simplegrid_legend'] = 'Grid Configuration (DMA SimpleGrid)';

--- a/src/dma_simple_grid/languages/en/tl_form_field.php
+++ b/src/dma_simple_grid/languages/en/tl_form_field.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_form_field']['dma_simplegrid_columnsettings']           = array('Column settings', 'Here you can configure the grid columns.');
+$GLOBALS['TL_LANG']['tl_form_field']['dma_simplegrid_offsetsettings']           = array('Offset settings', 'Here you can configure the grid offset.');
+$GLOBALS['TL_LANG']['tl_form_field']['dma_simplegrid_pullsettings']             = array('Pull settings', 'Here you can configure the grid pull.');
+$GLOBALS['TL_LANG']['tl_form_field']['dma_simplegrid_pushsettings']             = array('Push settings', 'Here you can configure the grid push.');
+$GLOBALS['TL_LANG']['tl_form_field']['dma_simplegrid_additionalrowclasses']     = array('Additional row classes', 'Optionally select additional row classes for this element.');
+
+
+/**
+ * Legends
+ */
+$GLOBALS['TL_LANG']['tl_form_field']['dma_simplegrid_legend'] = 'Grid Configuration (DMA SimpleGrid)';

--- a/src/dma_simple_grid/languages/en/tl_settings.php
+++ b/src/dma_simple_grid/languages/en/tl_settings.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Fields
+ */
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGridType']                         = array('Grid Type', 'Please select a grid type.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useColumns']                  = array('Show column selectors', 'Click here to enable column selectors.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useOffset']                   = array('Show offset selectors', 'Click here to enable offset selectors.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useOffsetRight']              = array('Show offset-right selectors', 'Click here to enable offset-right selectors.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_usePush']                     = array('Show push selectors', 'Click here to enable push selectors.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_usePull']                     = array('Show pull selectors', 'Click here to enable pull selectors.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useAdditionalWrapperClasses'] = array('Show advanced wrapper classes', 'Click here to enable advanced wrapper classes.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useAdditionalRowClasses']     = array('Show advanced row classes', 'Click here to enable advanced row classes.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useAdditionalColumnClasses']  = array('Show advanced column classes', 'Click here to enable advanced column classes.');
+$GLOBALS['TL_LANG']['tl_settings']['dmaSimpleGrid_useBlockGrid']                = array('Use block grid', 'Click here to use a block grid.');
+
+/**
+ * Palettes
+ */
+$GLOBALS['TL_LANG']['tl_settings']['dma_simplegrid_legend'] = "DMA SimpleGrid Settings";


### PR DESCRIPTION
Full english translation, because otherwise no labels would be shown in a non-german backend.

I've removed the `modules.php` from german because it seems obsolete (there's no backend module for SimpleGrid).

The translations are user-optimized, I think the user does not need to know about "SimpleGrid", but he usually knows about a grid. I've kept "SimpleGrid" in the groups and legends to keep a reference to the product and company. Hope you can agree with that.

If you want me to I can also adjust the german labels to follow that style :-)
