### PR TITLE
Added the option to hide a column

### DIFF
--- a/src/dma_simple_grid/classes/DmaSimpleGrid.php
+++ b/src/dma_simple_grid/classes/DmaSimpleGrid.php
@@ -117,7 +117,11 @@ class DmaSimpleGrid
             if (is_array($arrElementSettings)) {
                 foreach ($arrElementSettings as $columnKey => $varValue) {
                     if ($varValue) {
-                        $arrConfiguredClasses[] = sprintf(static::$arrCache['grid']['config']['columns-config'][$columnKey]['column-class'], $varValue);
+                        if ($varValue === 'hide') {
+                            $arrConfiguredClasses[] = static::$arrCache['grid']['config']['columns-config'][$columnKey]['hide-class'];
+                        } else {
+                            $arrConfiguredClasses[] = sprintf(static::$arrCache['grid']['config']['columns-config'][$columnKey]['column-class'], $varValue);
+                        }
                     }
                 }
             }
@@ -251,7 +255,7 @@ class DmaSimpleGrid
 
     }
 
-    public static function columnsSelectCallback()
+    public static function columnsSelectCallback(\Widget $widget = null)
     {
         if (!isset(static::$arrCache['grid']))
         {
@@ -262,11 +266,23 @@ class DmaSimpleGrid
 
         if (static::$arrCache['grid']['config']['columns-config']) {
             foreach (static::$arrCache['grid']['config']['columns-config'] as $configName => $arrColumnConfig) {
+                $options = [];
+
+                // Add the hide option for column settings
+                if ($widget !== null && $widget->dataContainer->field === 'dma_simplegrid_columnsettings' && isset($arrColumnConfig['hide-class'])) {
+                    $options['hide'] = &$GLOBALS['TL_LANG']['MSC']['dma_simplegrid_hidden'];
+                }
+
+                // Add the column sizes
+                foreach (static::$arrCache['grid']['config']['columns-sizes'] as $column) {
+                    $options[$column] = $column;
+                }
+
                 $arrColumnsSetting[$configName] = array
                 (
                     'label' => $arrColumnConfig['name'],
                     'inputType' => 'select',
-                    'options' => static::$arrCache['grid']['config']['columns-sizes'],
+                    'options' => $options,
                     'eval' => array('includeBlankOption' => true, 'style' => 'width:115px')
                 );
             }

--- a/src/dma_simple_grid/config/config.php
+++ b/src/dma_simple_grid/config/config.php
@@ -115,7 +115,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap'] = array
                 'column-class' => 'col-xs-%d',
                 'offset-class' => 'col-xs-offset-%d',
                 'push-class' => 'col-xs-push-%d',
-                'pull-class' => 'col-xs-pull-%d'
+                'pull-class' => 'col-xs-pull-%d',
+                'hide-class' => 'hidden-xs',
             ),
             'sm' => array
             (
@@ -123,7 +124,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap'] = array
                 'column-class' => 'col-sm-%d',
                 'offset-class' => 'col-sm-offset-%d',
                 'push-class' => 'col-sm-push-%d',
-                'pull-class' => 'col-sm-pull-%d'
+                'pull-class' => 'col-sm-pull-%d',
+                'hide-class' => 'hidden-sm',
             ),
             'md' => array
             (
@@ -131,7 +133,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap'] = array
                 'column-class' => 'col-md-%d',
                 'offset-class' => 'col-md-offset-%d',
                 'push-class' => 'col-md-push-%d',
-                'pull-class' => 'col-md-pull-%d'
+                'pull-class' => 'col-md-pull-%d',
+                'hide-class' => 'hidden-md',
             ),
             'lg' => array
             (
@@ -139,7 +142,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap'] = array
                 'column-class' => 'col-lg-%d',
                 'offset-class' => 'col-lg-offset-%d',
                 'push-class' => 'col-lg-push-%d',
-                'pull-class' => 'col-lg-pull-%d'
+                'pull-class' => 'col-lg-pull-%d',
+                'hide-class' => 'hidden-lg',
             )
         )
     )
@@ -171,7 +175,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap4'] = array
                 'column-class' => 'col-%d',
                 'offset-class' => 'offset-%d',
                 'push-class' => 'push-%d',
-                'pull-class' => 'pull-%d'
+                'pull-class' => 'pull-%d',
+                'hide-class' => 'd-xs-none',
             ),
             'sm' => array
             (
@@ -179,7 +184,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap4'] = array
                 'column-class' => 'col-sm-%d',
                 'offset-class' => 'offset-sm-%d',
                 'push-class' => 'push-sm-%d',
-                'pull-class' => 'pull-sm-%d'
+                'pull-class' => 'pull-sm-%d',
+                'hide-class' => 'd-sm-none',
             ),
             'md' => array
             (
@@ -187,7 +193,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap4'] = array
                 'column-class' => 'col-md-%d',
                 'offset-class' => 'offset-md-%d',
                 'push-class' => 'push-md-%d',
-                'pull-class' => 'pull-md-%d'
+                'pull-class' => 'pull-md-%d',
+                'hide-class' => 'd-md-none',
             ),
             'lg' => array
             (
@@ -195,7 +202,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap4'] = array
                 'column-class' => 'col-lg-%d',
                 'offset-class' => 'offset-lg-%d',
                 'push-class' => 'push-lg-%d',
-                'pull-class' => 'pull-lg-%d'
+                'pull-class' => 'pull-lg-%d',
+                'hide-class' => 'd-lg-none',
             ),
             'xl' => array
             (
@@ -203,7 +211,8 @@ $GLOBALS['DMA_SIMPLEGRID_CONFIG']['bootstrap4'] = array
                 'column-class' => 'col-xl-%d',
                 'offset-class' => 'offset-xl-%d',
                 'push-class' => 'push-xl-%d',
-                'pull-class' => 'pull-xl-%d'
+                'pull-class' => 'pull-xl-%d',
+                'hide-class' => 'd-xl-none',
             )
         ),
         'additional-classes' => array

--- a/src/dma_simple_grid/languages/en/default.php
+++ b/src/dma_simple_grid/languages/en/default.php
@@ -18,3 +18,8 @@ $GLOBALS['TL_LANG']['FFL']['dma_simplegrid_row_start']    = array('Grid Row Star
 $GLOBALS['TL_LANG']['FFL']['dma_simplegrid_row_stop']     = array('Grid Row Stop');
 $GLOBALS['TL_LANG']['FFL']['dma_simplegrid_column_start'] = array('Grid Column Start');
 $GLOBALS['TL_LANG']['FFL']['dma_simplegrid_column_stop']  = array('Grid Column Stop');
+
+/**
+ * Miscellaneous
+ */
+$GLOBALS['TL_LANG']['MSC']['dma_simplegrid_hidden'] = 'Hidden';


### PR DESCRIPTION
If the grid config has the `hide-class` specified for a column, then the column selection gets a new option to hide the column for each breakpoint.

![2017-09-05 at 10 19](https://user-images.githubusercontent.com/193483/30051844-c6429fae-9223-11e7-91c9-978d488a3966.png)
